### PR TITLE
Enable debug logging through UI

### DIFF
--- a/custom_components/tekmar_482/manifest.json
+++ b/custom_components/tekmar_482/manifest.json
@@ -9,5 +9,6 @@
   "config_flow": true,
   "iot_class": "local_push",
   "integration_type": "hub",
+  "loggers": ["custom_components.tekmar_482"],
   "version": "0.9.8"
 }


### PR DESCRIPTION
Add loggers to manifest so you can enable/disable debug logging in the UI instead of having to edit a file.