### PR TITLE
Temps are rounded to accurately reflect Fahrenheit

### DIFF
--- a/custom_components/tekmar_482/climate.py
+++ b/custom_components/tekmar_482/climate.py
@@ -343,8 +343,7 @@ class ThaClimateThermostat(ThaClimateBase):
 
         else:
             try:
-                temp = degEtoC(self._tekmar_tha.cool_setpoint)  # degH need degC
-                return round(temp, 0)
+                return degEtoC(self._tekmar_tha.cool_setpoint)
 
             except TypeError:
                 return None
@@ -359,8 +358,7 @@ class ThaClimateThermostat(ThaClimateBase):
 
         else:
             try:
-                temp = degEtoC(self._tekmar_tha.heat_setpoint)  # degH need degC
-                return round(temp, 0)
+                return degEtoC(self._tekmar_tha.heat_setpoint)
 
             except TypeError:
                 return None
@@ -381,11 +379,11 @@ class ThaClimateThermostat(ThaClimateBase):
             cool_setpoint = kwargs.get(ATTR_TARGET_TEMP_HIGH)
 
         if heat_setpoint is not None:
-            heat_setpoint = int(degCtoE(heat_setpoint))
+            heat_setpoint = int(round(degCtoE(heat_setpoint), 0))
             await self._tekmar_tha.set_heat_setpoint_txqueue(heat_setpoint)
 
         if cool_setpoint is not None:
-            cool_setpoint = int(degCtoE(cool_setpoint))
+            cool_setpoint = int(round(degCtoE(cool_setpoint), 0))
             await self._tekmar_tha.set_cool_setpoint_txqueue(cool_setpoint)
 
     async def async_set_hvac_mode(self, hvac_mode):

--- a/custom_components/tekmar_482/number.py
+++ b/custom_components/tekmar_482/number.py
@@ -218,7 +218,7 @@ class ThaHeatSetpoint(ThaNumberBase):
         return self._tekmar_tha.config_heat_setpoint_max
 
     async def async_set_native_value(self, value: float) -> None:
-        heat_setpoint = int(degCtoE(value))
+        heat_setpoint = int(round(degCtoE(value), 0))
         await self._tekmar_tha.set_heat_setpoint_txqueue(heat_setpoint)
 
 
@@ -254,7 +254,7 @@ class ThaHeatSetpointDay(ThaHeatSetpoint):
             return None
 
     async def async_set_native_value(self, value: float) -> None:
-        heat_setpoint = int(degCtoE(value))
+        heat_setpoint = int(round(degCtoE(value), 0))
         await self._tekmar_tha.set_heat_setpoint_txqueue(heat_setpoint, 0x00)
 
 
@@ -290,7 +290,7 @@ class ThaHeatSetpointNight(ThaHeatSetpoint):
             return None
 
     async def async_set_native_value(self, value: float) -> None:
-        heat_setpoint = int(degCtoE(value))
+        heat_setpoint = int(round(degCtoE(value), 0))
         await self._tekmar_tha.set_heat_setpoint_txqueue(heat_setpoint, 0x03)
 
 
@@ -326,7 +326,7 @@ class ThaHeatSetpointAway(ThaHeatSetpoint):
             return None
 
     async def async_set_native_value(self, value: float) -> None:
-        heat_setpoint = int(degCtoE(value))
+        heat_setpoint = int(round(degCtoE(value), 0))
         await self._tekmar_tha.set_heat_setpoint_txqueue(heat_setpoint, 0x06)
 
 
@@ -381,7 +381,7 @@ class ThaCoolSetpoint(ThaNumberBase):
         return self._tekmar_tha.config_cool_setpoint_max
 
     async def async_set_native_value(self, value: float) -> None:
-        cool_setpoint = int(degCtoE(value))
+        cool_setpoint = int(round(degCtoE(value), 0))
         await self._tekmar_tha.set_cool_setpoint_txqueue(cool_setpoint)
 
 
@@ -417,7 +417,7 @@ class ThaCoolSetpointDay(ThaCoolSetpoint):
             return None
 
     async def async_set_native_value(self, value: float) -> None:
-        cool_setpoint = int(degCtoE(value))
+        cool_setpoint = int(round(degCtoE(value), 0))
         await self._tekmar_tha.set_cool_setpoint_txqueue(cool_setpoint, 0x00)
 
 
@@ -453,7 +453,7 @@ class ThaCoolSetpointNight(ThaCoolSetpoint):
             return None
 
     async def async_set_native_value(self, value: float) -> None:
-        cool_setpoint = int(degCtoE(value))
+        cool_setpoint = int(round(degCtoE(value), 0))
         await self._tekmar_tha.set_cool_setpoint_txqueue(cool_setpoint, 0x03)
 
 
@@ -489,5 +489,5 @@ class ThaCoolSetpointAway(ThaCoolSetpoint):
             return None
 
     async def async_set_native_value(self, value: float) -> None:
-        cool_setpoint = int(degCtoE(value))
+        cool_setpoint = int(round(degCtoE(value), 0))
         await self._tekmar_tha.set_cool_setpoint_txqueue(cool_setpoint, 0x06)


### PR DESCRIPTION
When using this component in a system with Fahrenheit, the temperatures are truncated instead of rounded resulting in the inability to set certain temperatures.