### PR TITLE
Clear check_configuration issue on connect

### DIFF
--- a/custom_components/tekmar_482/hub.py
+++ b/custom_components/tekmar_482/hub.py
@@ -311,10 +311,9 @@ class TekmarHub:
                 else:
                     _LOGGER.warning(f"Unknown device at address {address}")
 
-
             if not self.online:
                 ir.async_delete_issue(self._hass, DOMAIN, "check_configuration")
-                
+
             self.online = True
 
     async def run(self) -> None:


### PR DESCRIPTION
Clear the check_configuration issue (caused by failure to connect) on connect after successful setup.